### PR TITLE
Updated install instructions

### DIFF
--- a/docs/bpass.md
+++ b/docs/bpass.md
@@ -15,18 +15,33 @@ _NOTE: the Perl script (in data/) needs to be placed on the parent directory_
 * Execute the Perl script from the folder
 ``` ../convert_bpassv2.x.pl```
 
-_NOTE: If it complains about permissions grant the Perl file permissions_
+_NOTE: If it complains about permissions, grant the Perl file permissions_
 
 ```bash
 chmod +x convert_bpassv2.x.pl
 ```
-* Generate binary files from the resulting _.ascii_ files executing Cloudy ```~/c17.02/source/cloudy.exe```
+* Generate binary files from the resulting _.ascii_ files executing Cloudy 
+  ```bash
+  ~/c17.03/source/cloudy.exe
+  ```
 * Press ```enter```
-* Type ```compile star BPASSv2_imf135_100_burst_binary.ascii" ```
+* Type 
+  ```bash 
+  compile star BPASSv2_imf135_100_burst_binary.ascii" 
+  ```
 * Press ```enter``` again to generate the binaries.
 
 The binaries now need to be placed in a special location for Cloudy to use them.
 
-* Navigate to the Cloudy data directory ```cd ~/c17.02/data```
-* Create a binaries directory ```mkdir binaries```
-* Finally, copy the binary BPASS file to the binaries/ directory ``` cp bpass_v2p2.1_imf_chab300_burst_binary.mod ~/c17.02/data/binaries/```
+* Navigate to the Cloudy data directory 
+  ```bash
+  cd ~/c17.03/data
+  ```
+* Create a binaries directory 
+  ```bash
+  mkdir binaries
+  ```
+* Finally, copy the binary BPASS file to the binaries/ directory 
+  ```bash 
+  cp bpass_v2p2.1_imf_chab300_burst_binary.mod ~/c17.03/data/binaries/
+  ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,39 +1,67 @@
 # Installation
-pyNublado manages the creation of input scripts for CLOUDY, their execution and parsing of the resulting outputs. The installation has two steps: installing CLOUDY and installing pyNublado
+pyNublado manages the creation of input scripts for Cloudy runs, their execution, and parsing of the resulting outputs. This installation guide has two steps: installing CLOUDY and installing pyNublado
 
 ## Requirements
  * Python 3.7 or newer
- * Your favourite C++ compiler to build CLOUDY
+ * Your favourite C++ compiler to build Cloudy
 
 
 ## Installing CLOUDY
 Instructions from [the Cloudy wiki](https://gitlab.nublado.org/cloudy/cloudy/-/wikis/DownloadLinks):
 
-* Download the latest Cloudy version ```wget https://data.nublado.org/cloudy_releases/c17/c17.02.tar.gz --no-check-certificate```
-* Unpack the files ```tar xvfz c17.02.tar.gz```
-* Move CLOUDY to the root path ```mv c17.02 ~/c17.02```
-* Navigate to the source folder ```cd c17.02/source```
-* Build the executable ```make```
-Once installed, to test that the installation was successful:
-* Run the executable ```~/c17.02/source/cloudy.exe```
-* Type "test" then press ```Enter``` twice
+* Download the latest Cloudy version 
+  ```bash
+  wget https://data.nublado.org/cloudy_releases/c17/c17.03.tar.gz --no-check-certificate
+  ```
+* Unpack the files 
+  ```bash
+  tar xvfz c17.03.tar.gz
+  ```
+* Move the extracted Cloudy folder to where you want it to live, e.g. your home directory 
+  ```bash
+  mv c17.03 ~/c17.03
+  ```
+* Navigate to the source folder 
+  ```bash 
+  cd c17.03/source
+  ```
+* Build the executable 
+  ```bash
+  make
+  ```
+  
+Once installed, you can test whether the installation was successful:
+* Run the executable 
+  ```bash 
+  ~/c17.02/source/cloudy.exe
+  ```
+* Type "test" then press ```Enter``` **twice**
 * Cloudy should print some output, which ends with "Cloudy exited OK"
 
 
 ## Installing pyNublado
 
-1. Clone the repository ```git clone https://github.com/raulorteg/pyNublado```
+1. Clone the repository
+   ```bash 
+   git clone https://github.com/raulorteg/pyNublado
+   ```
 
-##### pip
+2. Install all dependencies, either via **pip** or **conda**
+
+### pip
 * Create virtual environment:
     * Update pip ``` python -m pip install pip --upgrade ```
     * Install ``` virtualenv ``` using pip ``` python -m pip install virtualenv ```
     * Create Virtual environment ``` virtualenv pynublado ```
     * Activate Virtual environment (Mac OS/Linux: ``` source pynublado/bin/activate ```, Windows: ``` pynublado\Scripts\activate ```)
-    * (_Note: to deactivate environemt run ``` deactivate ```_)
+    * Note: to deactivate environmet run ``` deactivate ```
 * Install requirements on the Virtual environment ``` python -m pip install -r requirements.txt ```
 
-##### conda
-In Anaconda (or Miniconda) environments the requirements can be installed like so:
-* ```conda config --add channels conda-forge```
-* ```conda install --yes --file requirements_conda.txt```
+### conda
+In an existing Anaconda (or Miniconda) environment the requirements can be installed like so:
+* ```bash
+  conda config --add channels conda-forge
+  ```
+* ```bash
+  conda install --yes --file requirements_conda.txt
+  ```


### PR DESCRIPTION
- changed version 17.02 to 17.03
- changed the inline code blocks to stand alone code blocks in the hope that Sphinx generated documentation can display commands  without line breaks, which are easier to copy & paste.
