### PR TITLE
Updated docs: fixed code blocks not getting parsed correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A package to run (a lot of) [Cloudy](https://nublado.org) models.
 Example of running Cloudy independently:
 1. Create a _[name].in_ file
 2. Navigate to the folder where the .in file is located
-3. Execute Cloudy from the directory ```~/c17.02/source/cloudy.exe [name].in```
+3. Execute Cloudy from the directory ```~/c17.03/source/cloudy.exe [name].in```
 
 
 ### Input parameters

--- a/docs/bpass.md
+++ b/docs/bpass.md
@@ -21,11 +21,13 @@ _NOTE: If it complains about permissions, grant the Perl file permissions_
 chmod +x convert_bpassv2.x.pl
 ```
 * Generate binary files from the resulting _.ascii_ files executing Cloudy 
+
   ```bash
   ~/c17.03/source/cloudy.exe
   ```
 * Press ```enter```
 * Type 
+
   ```bash 
   compile star BPASSv2_imf135_100_burst_binary.ascii" 
   ```
@@ -34,14 +36,17 @@ chmod +x convert_bpassv2.x.pl
 The binaries now need to be placed in a special location for Cloudy to use them.
 
 * Navigate to the Cloudy data directory 
+
   ```bash
   cd ~/c17.03/data
   ```
-* Create a binaries directory 
+* Create a binaries directory
+
   ```bash
   mkdir binaries
   ```
 * Finally, copy the binary BPASS file to the binaries/ directory 
+
   ```bash 
   cp bpass_v2p2.1_imf_chab300_burst_binary.mod ~/c17.03/data/binaries/
   ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,32 +9,39 @@ pyNublado manages the creation of input scripts for Cloudy runs, their execution
 ## Installing CLOUDY
 Instructions from [the Cloudy wiki](https://gitlab.nublado.org/cloudy/cloudy/-/wikis/DownloadLinks):
 
-* Download the latest Cloudy version 
+* Download the latest Cloudy version
+
   ```bash
   wget https://data.nublado.org/cloudy_releases/c17/c17.03.tar.gz --no-check-certificate
   ```
-* Unpack the files 
+* Unpack the files
+
   ```bash
   tar xvfz c17.03.tar.gz
   ```
-* Move the extracted Cloudy folder to where you want it to live, e.g. your home directory 
+* Move the extracted Cloudy folder to where you want it to live, e.g. your home directory
+
   ```bash
   mv c17.03 ~/c17.03
   ```
 * Navigate to the source folder 
+
   ```bash 
-  cd c17.03/source
+  cd ~/c17.03/source
   ```
 * Build the executable 
+
   ```bash
   make
   ```
   
 Once installed, you can test whether the installation was successful:
-* Run the executable 
+* Run the executable
+
   ```bash 
-  ~/c17.02/source/cloudy.exe
+  ~/c17.03/source/cloudy.exe
   ```
+
 * Type "test" then press ```Enter``` **twice**
 * Cloudy should print some output, which ends with "Cloudy exited OK"
 
@@ -42,6 +49,7 @@ Once installed, you can test whether the installation was successful:
 ## Installing pyNublado
 
 1. Clone the repository
+
    ```bash 
    git clone https://github.com/raulorteg/pyNublado
    ```
@@ -59,9 +67,11 @@ Once installed, you can test whether the installation was successful:
 
 ### conda
 In an existing Anaconda (or Miniconda) environment the requirements can be installed like so:
+
 * ```bash
   conda config --add channels conda-forge
   ```
+
 * ```bash
   conda install --yes --file requirements_conda.txt
   ```

--- a/src/user_settings.py
+++ b/src/user_settings.py
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------
 #
 # Cloudy executable
-CLOUDY_PATH = '~/c17.02/source/cloudy.exe'
+CLOUDY_PATH = '~/c17.03/source/cloudy.exe'
 
 # time out for individual cloudy runs in seconds
 CLOUDY_RUN_TIMEOUT = 7200


### PR DESCRIPTION
The code blocks where not getting parsed correctly because of a missing space between the previous line. Also updated the cloudy version in the common.settings and in a couple of places in the documentation

this is a test
```bash
echo "test"
```

gets rewritten as:

this is a test

```bash
echo "test"
```
