### PR TITLE
Small change: Disable chunking of queue jobs submitted to worker pool

### DIFF
--- a/scripts/check_run.py
+++ b/scripts/check_run.py
@@ -207,7 +207,7 @@ def check_run(N_sample, colormap=matplotlib.cm.viridis, show_plot=True):
     # Accounting array
     outcome_array = np.zeros(len(run_key))
 
-    print(F"\nReading model.out files")
+    print(F"\nReading model outcomes for all models in {sample_dir}")
 
     for i in tqdm(range(len(model_dir_list))):
 
@@ -239,9 +239,9 @@ def check_run(N_sample, colormap=matplotlib.cm.viridis, show_plot=True):
             run_space[i] = 7
             outcome_array[7] += 1
 
-    print(F"\n {n_models_total} models in total in this sample")
-    print(F" {n_models_processed} models processed ({np.round(100 * n_models_processed/n_models_total, 2)}%)")
-    print(F" Breakdown of the EXIT codes:\n")
+    print(F"\n{n_models_total} models in total in this sample")
+    print(F"{n_models_processed} models processed ({np.round(100 * n_models_processed/n_models_total, 2)}%)")
+    print(F"Breakdown of the EXIT codes:\n")
     for i in range(len(run_key)):
         outcome_percent = np.round(100 * outcome_array[i] / n_models_processed, 2)
         print(F"\t{outcome_percent}% \t|\t{i}: {run_key[i]} ")

--- a/src/manager.py
+++ b/src/manager.py
@@ -121,7 +121,7 @@ class QueueManager:
             if self.verbose: print('Initialising {} threads'.format(self.N_CPUs))
             pool = multiprocessing.Pool(processes=self.N_CPUs, maxtasksperchild=1)
 
-            pool.map(self._run_model, self.models_to_run)
+            pool.map(func=self._run_model, iterable=self.models_to_run, chunksize=1)
 
             pool.close()
             pool.join()


### PR DESCRIPTION
When using multiprocessing with a pool of worker processes the map function will by default cut up the job queue into chunks of a certain size and submit each chunk to a worker. This can result in some workers sitting idle after completing their chunk, while others are still working through their share of the queue.  

The issue is noticeable towards the end of a run, when a hand full of processes keep re-loading more models, while most of the other workers do nothing.  I made a minor modification, so that the chunk size is one.  It should prevent idle processes until the very end of the run.

