### PR TITLE
fix: Missing requirements for scripts/run_parser.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest
 tqdm
 gdown
 pandas
+seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib>=3.5.0
 pytest
 tqdm
 gdown
+pandas

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -6,3 +6,4 @@ pytest
 tqdm
 gdown
 pandas
+seaborn

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -5,3 +5,4 @@ matplotlib>=3.5.0
 pytest
 tqdm
 gdown
+pandas


### PR DESCRIPTION
A couple of packages that are needed by `scripts/run_parser.py`  are currently missing from the `requirements*.txt` files . This PR solves the issue.